### PR TITLE
update package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 setup(
-    name='compmed',
+    name='compmed-pkg',
     version='0.1',
     packages=['compmed', 'compmed_utils'],
     include_package_data=True,


### PR DESCRIPTION
`compmed_utils` cannot found after installation.

if the module name and package name are the same, it will only build the spcific package (e.g., compmed) during installation.